### PR TITLE
Redesign RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,7 @@ rc_rmq.start_consume({
   'cb': callback_function
 })
 
+
+# don't forget to close connection
+rc_rmq.disconnect()
 ```

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ def callback_function(ch, method, properties, body):
 # start consume messagre from queue with callback function
 rc_rmq.start_consume({
   'queue': 'queue_name',
+  'routing_key: 'your_key',
   'cb': callback_function
 })
-
 
 # don't forget to close connection
 rc_rmq.disconnect()

--- a/agent_template.py
+++ b/agent_template.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import sys
+import json
+from rc_rmq import RCRMQ
+
+task = 'task_name'
+
+# Instantiate rabbitmq object
+rc_rmq = RCRMQ({'exchange': 'RegUsr', 'exchange_type': 'topic'})
+
+# Define your callback function
+def on_message(ch, method, properties, body):
+
+    # Retrieve routing key
+    routing_key = method.routing_key
+
+    # Retrieve message
+    msg = json.loads(body)
+
+    # Do Something
+    print('[{}]: Callback called.'.format(task))
+
+    # Acknowledge message
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+
+print("Start listening to queue: {}".format(task))
+rc_rmq.start_consume({
+    'queue': task,      # Define your Queue name
+    'routing_key': "#", # Define your routing key
+    'cb': on_message    # Pass in callback function you just define
+})

--- a/create_account.py
+++ b/create_account.py
@@ -3,14 +3,22 @@ import sys
 import rc_util
 
 if len(sys.argv) < 2:
-    print("Usage: {} USERNAME [FULL_NAME] [REASON]".format(sys.argv[0]), file=sys.stderr)
+    print("Usage: {} USERNAME [EMAIL] [FULL_NAME] [REASON]".format(sys.argv[0]), file=sys.stderr)
     exit(1)
 
+domain = 'uab.edu'
 user_name = sys.argv[1]
-full_name = sys.argv[2] if len(sys.argv) >= 3 else ''
-reason    = sys.argv[3] if len(sys.argv) >= 4 else ''
+email = sys.argv[2] if len(sys.argv) >= 3 else ''
+full_name = sys.argv[3] if len(sys.argv) >= 4 else ''
+reason    = sys.argv[4] if len(sys.argv) >= 5 else ''
 
-rc_util.add_account(user_name, full=full_name, reason=reason)
+if email == '':
+    if '@' in user_name:
+        email = user_name
+    else:
+        email = user_name + '@' + domain
+
+rc_util.add_account(user_name, email=email, full=full_name, reason=reason)
 print("Account requested for user: {}".format(user_name))
 
 print("Waiting for confirmation...")

--- a/create_account.py
+++ b/create_account.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import sys
+import rc_util
+
+if len(sys.argv) < 2:
+    print("Usage: {} USERNAME [FULL_NAME] [REASON]".format(sys.argv[0]), file=sys.stderr)
+    exit(1)
+
+user_name = sys.argv[1]
+full_name = sys.argv[2] if len(sys.argv) >= 3 else ''
+reason    = sys.argv[3] if len(sys.argv) >= 4 else ''
+
+rc_util.add_account(user_name, full=full_name, reason=reason)
+print("Account requested for user: {}".format(user_name))
+
+print("Waiting for confirmation...")
+rc_util.consume(user_name)

--- a/ohpc_account_create.py
+++ b/ohpc_account_create.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-import pika # python client
 import sys
-import rabbit_config as rcfg
-import socket
-import subprocess
-import time
 import json
+import subprocess
 from pwd import getpwnam
 from rc_rmq import RCRMQ
 

--- a/ohpc_account_create.py
+++ b/ohpc_account_create.py
@@ -7,57 +7,48 @@ import subprocess
 import time
 import json
 from pwd import getpwnam
+from rc_rmq import RCRMQ
 
-hostname = socket.gethostname().split(".", 1)[0]
-connect_host = rcfg.Server if hostname != rcfg.Server else "localhost"
-queue_name = "ohpc_account_create"
-duration = 2
+task = "ohpc_account"
 
-# Set up credentials to connect to RabbitMQ server
-credentials = pika.PlainCredentials(rcfg.User, rcfg.Password)
-parameters = pika.ConnectionParameters(connect_host,
-                                   rcfg.Port,
-                                   rcfg.VHost,
-                                   credentials)
-
-# Establish connection to RabbitMQ server
-connection = pika.BlockingConnection(parameters)
-channel = connection.channel()
-
-print("connection established. Listening for messages:")
-
-# create exchange to pass messages
-channel.exchange_declare(exchange=rcfg.Exchange, exchange_type='direct')
-
-# creates a random name for the newly generated queue
-result = channel.queue_declare(queue=queue_name, exclusive=False)
-
-channel.queue_bind(exchange=rcfg.Exchange, queue=queue_name, routing_key=queue_name)
+# Instantiate rabbitmq object
+rc_rmq = RCRMQ({'exchange': 'RegUsr', 'exchange_type': 'topic'})
 
 def ohpc_account_create(ch, method, properties, body):
     msg = json.loads(body)
     print("Message received {}".format(msg))
     username = msg['username']
+    success = False
     try:
         subprocess.call(["sudo", "useradd", username])
-        print("User {} has been added to {}".format(username, hostname))
+        print("[{}]: User {} has been added".format(task, username))
+        success = True
     except:
         print("Failed to create user")
 
-    channel.basic_ack(delivery_tag=method.delivery_tag)
+    ch.basic_ack(delivery_tag=method.delivery_tag)
     msg['uid'] = getpwnam(username).pw_uid
     msg['gid'] = getpwnam(username).pw_gid
-    channel.basic_publish(exchange=rcfg.Exchange, routing_key='ood_account_create', body=json.dumps(msg))
 
+    # send confirm message
+    rc_rmq.publish_msg({
+        'routing_key': 'confirm.' + username,
+        'msg': {
+            'task': task,
+            'success': success
+        }
+    })
 
-# ingest messages
-channel.basic_consume(queue=queue_name, on_message_callback=ohpc_account_create)
+    if success:
+        # send create message to other agent
+        rc_rmq.publish_msg({
+            'routing_key': 'create.' + username,
+            'msg': msg
+        })
 
-# initiate message ingestion
-try:
-    channel.start_consuming()
-except KeyboardInterrupt:
-    print("Disconnecting from broker.")
-    channel.stop_consuming()
-
-connection.close()
+print("Start Listening to queue: {}".format(task))
+rc_rmq.start_consume({
+    'queue': task,
+    'routing_key': 'request.*',
+    'cb': ohpc_account_create
+})

--- a/ohpc_account_create.py
+++ b/ohpc_account_create.py
@@ -20,7 +20,8 @@ def ohpc_account_create(ch, method, properties, body):
         print("[{}]: User {} has been added".format(task, username))
         success = True
     except:
-        print("Failed to create user")
+        e = sys.exc_info()[0]
+        print("[{}]: Error: {}".format(task, e))
 
     ch.basic_ack(delivery_tag=method.delivery_tag)
     msg['uid'] = getpwnam(username).pw_uid

--- a/ood_account_create.py
+++ b/ood_account_create.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-import pika # python client
 import sys
-import rabbit_config as rcfg
-import socket
-import subprocess
-import time
 import json
+import subprocess
 from rc_rmq import RCRMQ
 
 task = 'ood_account'

--- a/ood_account_create.py
+++ b/ood_account_create.py
@@ -22,7 +22,8 @@ def ood_account_create(ch, method, properties, body):
         print("[{}]: User {} has been added".format(task, username))
         success = True
     except:
-        print("Failed to create user")
+        e = sys.exc_info()[0]
+        print("[{}]: Error: {}".format(task, e))
 
     ch.basic_ack(delivery_tag=method.delivery_tag)
 

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -65,11 +65,11 @@ class RCRMQ(object):
                 exchange_type=self.EXCHANGE_TYPE,
                 durable=True)
 
-        if self.QUEUE is not None:
-            self._channel.queue_declare(queue=self.QUEUE, durable=self.DURABLE)
-            self._channel.queue_bind(exchange=self.EXCHANGE,
-                    queue=self.QUEUE,
-                    routing_key=self.ROUTING_KEY)
+    def bind_queue(self):
+        self._channel.queue_declare(queue=self.QUEUE, durable=self.DURABLE)
+        self._channel.queue_bind(exchange=self.EXCHANGE,
+                queue=self.QUEUE,
+                routing_key=self.ROUTING_KEY)
 
     def disconnect(self):
         self._channel.close()
@@ -102,6 +102,8 @@ class RCRMQ(object):
 
         if self._connection is None:
             self.connect()
+
+        self.bind_queue()
 
         self._consumer_tag = self._channel.basic_consume(self.QUEUE,obj['cb'])
         self._consuming = True

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -82,13 +82,15 @@ class RCRMQ(object):
         if 'routing_key' in obj:
             self.ROUTING_KEY = obj['routing_key']
 
-        self.connect()
+        if self._connection is None:
+            self.connect()
 
         self._channel.basic_publish(exchange=self.EXCHANGE,
                 routing_key=self.ROUTING_KEY,
                 body=json.dumps(obj['msg']))
 
-        self.disconnect()
+        if not self._consuming:
+            self.disconnect()
 
     def start_consume(self, obj):
         if 'queue' in obj:
@@ -100,9 +102,11 @@ class RCRMQ(object):
         if self.DEBUG:
             print("Queue: " + self.QUEUE + "\nRouting_key: " + self.ROUTING_KEY)
 
-        self.connect()
+        if self._connection is None:
+            self.connect()
 
         self._consumer_tag = self._channel.basic_consume(self.QUEUE,obj['cb'])
+        self._consuming = True
         try:
             self._channel.start_consuming()
         except KeyboardInterrupt:

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -44,6 +44,10 @@ class RCRMQ(object):
               Port: {}
             """.format(self.EXCHANGE, self.EXCHANGE_TYPE, self.HOST, self.USER, self.VHOST, self.PORT))
 
+        self._consumer_tag = None
+        self._connection = None
+        self._consuming = False
+        self._channel = None
         self._parameters = pika.ConnectionParameters(
                 self.HOST,
                 self.PORT,

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -74,6 +74,7 @@ class RCRMQ(object):
     def disconnect(self):
         self._channel.close()
         self._connection.close()
+        self._connection = None
 
     def delete_queue(self):
         self._channel.queue_delete(self.QUEUE)
@@ -88,9 +89,6 @@ class RCRMQ(object):
         self._channel.basic_publish(exchange=self.EXCHANGE,
                 routing_key=self.ROUTING_KEY,
                 body=json.dumps(obj['msg']))
-
-        if not self._consuming:
-            self.disconnect()
 
     def start_consume(self, obj):
         if 'queue' in obj:
@@ -111,8 +109,6 @@ class RCRMQ(object):
             self._channel.start_consuming()
         except KeyboardInterrupt:
             self._channel.stop_consuming()
-
-        self.disconnect()
 
     def stop_consume(self):
         self._channel.basic_cancel(self._consumer_tag)

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -61,7 +61,7 @@ class RCRMQ(object):
         self._connection = pika.BlockingConnection(self._parameters)
         self._channel = self._connection.channel()
         self._channel.exchange_declare(
-                exchange=self.EXCHANGE, 
+                exchange=self.EXCHANGE,
                 exchange_type=self.EXCHANGE_TYPE,
                 durable=True)
 

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -15,8 +15,9 @@ class RCRMQ(object):
     QUEUE = None
     DURABLE = True
     ROUTING_KEY = None
+    DEBUG = False
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, debug=False):
         if config:
             if 'exchange' in config:
                 self.EXCHANGE = config['exchange']
@@ -30,6 +31,19 @@ class RCRMQ(object):
         self.PASSWORD = rcfg.Password
         self.VHOST = rcfg.VHost
         self.PORT = rcfg.Port
+        self.DEBUG = debug
+
+        if self.DEBUG:
+            print("""
+            Created RabbitMQ instance with:
+              Exchange name: {},
+              Exchange type: {},
+              Host: {},
+              User: {},
+              VHost: {},
+              Port: {}
+            """.format(self.EXCHANGE, self.EXCHANGE_TYPE, self.HOST, self.USER, self.VHOST, self.PORT))
+
         self._parameters = pika.ConnectionParameters(
                 self.HOST,
                 self.PORT,
@@ -37,6 +51,9 @@ class RCRMQ(object):
                 pika.PlainCredentials(self.USER, self.PASSWORD))
 
     def connect(self):
+        if self.DEBUG:
+            print("Connecting...\n" + "Exchange: " + self.EXCHANGE + " Exchange type: " + self.EXCHANGE_TYPE)
+
         self._connection = pika.BlockingConnection(self._parameters)
         self._channel = self._connection.channel()
         self._channel.exchange_declare(
@@ -75,6 +92,9 @@ class RCRMQ(object):
             self.ROUTING_KEY = obj['routing_key'] if 'routing_key' in obj else self.QUEUE
         if 'durable' in obj:
             self.DURABLE = obj['durable']
+
+        if self.DEBUG:
+            print("Queue: " + self.QUEUE + "\nRouting_key: " + self.ROUTING_KEY)
 
         self.connect()
 

--- a/rc_util.py
+++ b/rc_util.py
@@ -4,11 +4,12 @@ import json
 rc_rmq = RCRMQ({'exchange': 'RegUsr', 'exchange_type': 'topic'})
 tasks = {'ohpc_account': None, 'ood_account': None, 'slurm_account': None}
 
-def add_account(username, full='', reason=''):
+def add_account(username, email, full='', reason=''):
   rc_rmq.publish_msg({
     'routing_key': 'request.' + username,
     'msg': {
       "username": username,
+      "email": email,
       "fullname": full,
       "reason": reason
     }

--- a/rc_util.py
+++ b/rc_util.py
@@ -30,7 +30,7 @@ def worker(ch, method, properties, body):
         rc_rmq.stop_consume()
         rc_rmq.delete_queue()
 
-def consume(username, callback, debug=False):
+def consume(username, callback=worker, debug=False):
     if debug:
         sleep(5)
     else:

--- a/rc_util.py
+++ b/rc_util.py
@@ -13,6 +13,7 @@ def add_account(username, full='', reason=''):
       "reason": reason
     }
   })
+  rc_rmq.disconnect()
 
 def worker(ch, method, properties, body):
     msg = json.loads(body)
@@ -39,5 +40,6 @@ def consume(username, callback=worker, debug=False):
             'routing_key': 'confirm.' + username,
             'cb': callback
         })
+        rc_rmq.disconnect()
 
     return { 'success' : True }

--- a/rc_util.py
+++ b/rc_util.py
@@ -25,11 +25,11 @@ def worker(ch, method, properties, body):
     for key, status in tasks.items():
         if not status:
             print("{} is not done yet.".format(key))
-            done = False 
+            done = False
     if done:
         confirm_rmq.stop_consume()
         confirm_rmq.delete_queue()
-  
+
 def consume(username, callback, debug=False):
     if debug:
         sleep(5)
@@ -39,5 +39,5 @@ def consume(username, callback, debug=False):
             'routing_key': 'confirm.' + username,
             'cb': callback
         })
-  
+
     return { 'success' : True }

--- a/rc_util.py
+++ b/rc_util.py
@@ -1,9 +1,11 @@
+import logging
 import argparse
 from rc_rmq import RCRMQ
 import json
 
 rc_rmq = RCRMQ({'exchange': 'RegUsr', 'exchange_type': 'topic'})
 tasks = {'ohpc_account': None, 'ood_account': None, 'slurm_account': None}
+logger_fmt = '%(asctime)s [%(module)s] - %(message)s'
 
 def add_account(username, email, full='', reason=''):
   rc_rmq.publish_msg({
@@ -52,3 +54,19 @@ def get_args():
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
     parser.add_argument('-n', '--dry-run', action='store_true', help='enable dry run mode')
     return parser.parse_args()
+
+def get_logger(args=None):
+    if args is None:
+        args = get_args()
+
+    logger_lvl = logging.WARNING
+
+    if args.verbose:
+        logger_lvl = logging.DEBUG
+
+    if args.dry_run:
+        logger_lvl = logging.INFO
+
+    logging.basicConfig(format=logger_fmt, level=logger_lvl)
+    return logging.getLogger(__name__)
+

--- a/rc_util.py
+++ b/rc_util.py
@@ -27,14 +27,14 @@ def worker(ch, method, properties, body):
             print("{} is not done yet.".format(key))
             done = False
     if done:
-        confirm_rmq.stop_consume()
-        confirm_rmq.delete_queue()
+        rc_rmq.stop_consume()
+        rc_rmq.delete_queue()
 
 def consume(username, callback, debug=False):
     if debug:
         sleep(5)
     else:
-        confirm_rmq.start_consume({
+        rc_rmq.start_consume({
             'queue': username,
             'routing_key': 'confirm.' + username,
             'cb': callback

--- a/rc_util.py
+++ b/rc_util.py
@@ -1,3 +1,4 @@
+import argparse
 from rc_rmq import RCRMQ
 import json
 
@@ -44,3 +45,10 @@ def consume(username, callback=worker, debug=False):
         rc_rmq.disconnect()
 
     return { 'success' : True }
+
+def get_args():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('-n', '--dry-run', action='store_true', help='enable dry run mode')
+    return parser.parse_args()

--- a/slurm_agent.py
+++ b/slurm_agent.py
@@ -16,7 +16,7 @@ def slurm_account_create(ch, method, properties, body):
     success = False
     try:
         subprocess.call(["sudo", "sacctmgr", "add", "account", username, "-i",  "Descripition: Add user"])
-        subprocess.call(["sudo", "sacctmgr", "add", "user", username, "account="+username, "-i"])
+        subprocess.call(["sudo", "sacctmgr", "add", "user", username, "account=" + username, "-i"])
         print("SLURM account for user {} has been added".format(username))
         success = True
     except:

--- a/slurm_agent.py
+++ b/slurm_agent.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-import pika # python client
 import sys
-import rabbit_config as rcfg
-import socket
-import subprocess
-import time
 import json
+import subprocess
 from rc_rmq import RCRMQ
 
 task = 'slurm_account'

--- a/slurm_agent.py
+++ b/slurm_agent.py
@@ -6,60 +6,40 @@ import socket
 import subprocess
 import time
 import json
+from rc_rmq import RCRMQ
 
-hostname = socket.gethostname().split(".", 1)[0]
-connect_host = rcfg.Server if hostname != rcfg.Server else "localhost"
-queue_name = "slurm_add_account"
-duration = 2
+task = 'slurm_account'
 
-# Set up credentials to connect to RabbitMQ server
-credentials = pika.PlainCredentials(rcfg.User, rcfg.Password)
-parameters = pika.ConnectionParameters(connect_host,
-                                   rcfg.Port,
-                                   rcfg.VHost,
-                                   credentials)
-
-# Establish connection to RabbitMQ server
-connection = pika.BlockingConnection(parameters)
-channel = connection.channel()
-
-print("connection established. Listening for messages:")
-
-# create exchange to pass messages
-channel.exchange_declare(exchange=rcfg.Exchange, exchange_type='direct')
-
-# creates a random name for the newly generated queue
-result = channel.queue_declare(queue=queue_name, exclusive=False)
-
-channel.queue_bind(exchange=rcfg.Exchange, queue=queue_name, routing_key=queue_name)
+# Instantiate rabbitmq object
+rc_rmq = RCRMQ({'exchange': 'RegUsr', 'exchange_type': 'topic'})
 
 def slurm_account_create(ch, method, properties, body):
     msg = json.loads(body)
     print("Message received {}".format(msg))
     username = msg['username']
+    success = False
     try:
         subprocess.call(["sudo", "sacctmgr", "add", "account", username, "-i",  "Descripition: Add user"])
         subprocess.call(["sudo", "sacctmgr", "add", "user", username, "account="+username, "-i"])
         print("SLURM account for user {} has been added".format(username))
+        success = True
     except:
         print("Failed to create user")
     
-    channel.basic_ack(delivery_tag=method.delivery_tag)
-        
-    channel.basic_publish(exchange=rcfg.Exchange, routing_key=username, body=json.dumps(msg))
-    
+    ch.basic_ack(delivery_tag=method.delivery_tag)
 
-# ingest messages
-channel.basic_consume(queue=queue_name, on_message_callback=slurm_account_create)
+    # send confirm message
+    rc_rmq.publish_msg({
+        'routing_key': 'confirm.' + username,
+        'msg': {
+            'task': task,
+            'success': success
+        }
+    })
 
-# initiate message ingestion
-try:
-    channel.start_consuming()
-except KeyboardInterrupt:
-    print("Disconnecting from broker.")
-    channel.stop_consuming()
-
-connection.close()
-
-        
-    
+print("Start listening to queue: {}".format(task))
+rc_rmq.start_consume({
+    'queue': task,
+    'routing_key': "create.*",
+    'cb': slurm_account_create
+})

--- a/slurm_agent.py
+++ b/slurm_agent.py
@@ -20,8 +20,9 @@ def slurm_account_create(ch, method, properties, body):
         print("SLURM account for user {} has been added".format(username))
         success = True
     except:
-        print("Failed to create user")
-    
+        e = sys.exc_info()[0]
+        print("[{}]: Error: {}".format(task, e))
+
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
     # send confirm message


### PR DESCRIPTION
Ohpc account (uid resolver): 
- subscribe pattern `request.*`
- send out message, `uid` and `gid` attached, with routing_key `create.<username>`to other agents if `uid` and `gid` create/resolve successfully
message body:
```
{
  "username": "user1010",
  "fullname": "User 1010",
  "reason": "Reason1, 2 and 3",
  "uid": "1234",
  "gid": "1234"
}
```

- send out confirmation with routing_key `confirm.<username>`
message body: 

```
{
  "task": "ohpc_account",
  "success": true // false if task failed
}
```

Ood account:
- subscribe pattern `create.*` 
- send out confirmation with routing_key `confirm.<username>`
message body:

```
{
  "task": "ood_account",
  "success": true // false if task failed
}
```

Slurm account:
- subscribe pattern `create.*` 
- send out confirmation with routing_key `confirm.<username>`
message body:

```
{
  "task": "slurm_account",
  "success": true // false if task failed
}
```

Celery Task could be using `add_account` and `consume` function defined in `rc_util`
`add_account` sent out request message with routint_key `request.<username>`
`consume` will subscribe to `confirm.<username>` to keep tracking status of all tasks.