### PR TITLE
Add get_args function in rc_util

### DIFF
--- a/rc_util.py
+++ b/rc_util.py
@@ -1,3 +1,4 @@
+import argparse
 from rc_rmq import RCRMQ
 import json
 
@@ -41,3 +42,10 @@ def consume(username, callback, debug=False):
         })
   
     return { 'success' : True }
+
+def get_args():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
+    parser.add_argument('-n', '--dry-run', action='store_true', help='enable dry run mode')
+    return parser.parse_args()


### PR DESCRIPTION
Instead of include this chunk of code in every agent, move it to `rc_util` should be cleaner way.