### PR TITLE
Create /data/user /data/scratch dirs if they don't exist

### DIFF
--- a/dir_verify.py
+++ b/dir_verify.py
@@ -31,7 +31,7 @@ def dir_verify(ch, method, properties, body):
             else:
                 if not path.exists():
                     # Make sure folder exists and with right permission
-                    path.mkdir(mode=0o700)
+                    path.mkdir(mode=0o700, parents=True, exist_ok=True)
 
                     # Make sure ownership is correct
                     shutil.chown(path, int(msg['uid']), int(msg['gid']))


### PR DESCRIPTION
This PR will fix the need for parent dirs /data/user and /data/scratch to exist while creating the paths /data/user/$USER and /data/scratch/$USER as a part of dir_verify agent