### PR TITLE
Fix acct. creation and ldapsearch concurrency issue

### DIFF
--- a/get-next-uid-gid.py
+++ b/get-next-uid-gid.py
@@ -2,6 +2,7 @@
 import sys
 import json
 import ldap
+import time
 import logging
 import argparse
 import rc_util
@@ -36,6 +37,7 @@ def create_account(msg):
 
         if not args.dry_run:
             popen(cmd)
+            time.sleep(1)
         logger.info(f'Bright command to create user:{cmd}')
     except Exception:
         logger.exception("Fatal cmsh error:")


### PR DESCRIPTION
This PR will fix the issue we saw with git_commit agent not able to produce ldif files, because the ldapsearch is trying to access the user record before the account creation process returns so we add a 1 second delay before we proceed to the next step.