### PR TITLE
Remove unnecessary ldap import

### DIFF
--- a/git_commit.py
+++ b/git_commit.py
@@ -3,7 +3,6 @@ import os
 import sh
 import sys
 import json
-import ldap
 import rc_util
 from rc_rmq import RCRMQ
 


### PR DESCRIPTION
ldap import is not necessary to use `ldapsearch` via `sh` library which invokes the system level ldapsearch. so we don't need to install or import any ldap packages as we are not doing native ldap programming here, we are simply invoking the ldapsearch on the underlying system (CoD).