### PR TITLE
Use a single merged config file for all agents 

### DIFF
--- a/get-next-uid-gid.py
+++ b/get-next-uid-gid.py
@@ -8,6 +8,7 @@ import argparse
 import rc_util
 from os import popen
 from rc_rmq import RCRMQ
+import rabbit_config as rcfg
 
 task = 'create_account'
 
@@ -37,7 +38,7 @@ def create_account(msg):
 
         if not args.dry_run:
             popen(cmd)
-            time.sleep(1)
+            time.sleep(rcfg.Delay)
         logger.info(f'Bright command to create user:{cmd}')
     except Exception:
         logger.exception("Fatal cmsh error:")

--- a/git_commit.py
+++ b/git_commit.py
@@ -6,6 +6,7 @@ import json
 import ldap
 import rc_util
 from rc_rmq import RCRMQ
+import rabbit_config as rmq_cfg
 
 task = 'git_commit'
 
@@ -13,7 +14,7 @@ task = 'git_commit'
 rc_rmq = RCRMQ({'exchange': 'RegUsr', 'exchange_type': 'topic'})
 
 # Define some location
-repo_location = os.path.expanduser('~/git/rc-users')
+repo_location = os.path.expanduser(rmq_cfg.rc_users_ldap_repo_loc)
 users_dir = repo_location + '/users'
 groups_dir = repo_location + '/groups'
 

--- a/notify_user.py
+++ b/notify_user.py
@@ -7,7 +7,7 @@ import dataset
 from rc_rmq import RCRMQ
 from jinja2 import Template
 from datetime import datetime
-import mail_config as mail_cfg
+import rabbit_config as mail_cfg
 
 task = 'notify_user'
 

--- a/rabbit_config.py.example
+++ b/rabbit_config.py.example
@@ -4,3 +4,39 @@ Password = 'CHANGE_IT_TO_YOUR_OWN_PASSWORD'
 VHost = '/'
 Server = 'ohpc'
 Port = 5672
+
+# git_commit agent config
+rc_users_ldap_repo_loc = "~/git/rc-users"
+
+# Config related to email
+Server = 'localhost'
+My_email = 'root@localhost'
+Sender = 'ROOT@LOCALHOST'
+Sender_alias = 'Services'
+Subject = 'New User Account'
+Info_url = 'https://www.google.com'
+Mail_list = 'root@localhost'
+Mail_list_bcc = 'cmsupport@localhost'
+
+Head = f"""From: {Sender_alias} <{Sender}>
+To: <{{{{ to }}}}>
+Subject: {Subject}
+"""
+
+Body = f"""
+Hi {{{{ username }}}}
+Your account has been set up with:
+
+============================
+User ID:  {{{{ username }}}}
+============================
+
+If you have any questions, please visit:
+{Info_url}
+
+or email at {My_email}
+
+Cheers,
+"""
+
+Whole_mail = Head + Body

--- a/subscribe_mail_lists.py
+++ b/subscribe_mail_lists.py
@@ -7,6 +7,7 @@ import argparse
 import rc_util
 from email.message import EmailMessage
 from rc_rmq import RCRMQ
+import rabbit_config as rcfg
 
 task = 'subscribe_mail_list'
 
@@ -28,8 +29,10 @@ def mail_list_subscription(ch, method, properties, body):
     fullname = msg['fullname']
     email = msg['email']
 
-    mail_list_admin = 'root@localhost' #change this during deploy
-    mail_list = 'LISTSERV@LISTSERV.UAB.EDU'
+    mail_list_admin = rcfg.Sender
+    mail_list = rcfg.Mail_list
+    mail_list_bcc = rcfg.Mail_list_bcc
+    server = rcfg.Server
 
     listserv_cmd = f'QUIET ADD hpc-announce {email} {fullname} \
                    \nQUIET ADD hpc-users {email} {fullname}'
@@ -43,9 +46,10 @@ def mail_list_subscription(ch, method, properties, body):
         email_msg['From'] = mail_list_admin
         email_msg['To'] = mail_list
         email_msg['Subject'] = ''
+        email_msg['Bcc'] = mail_list_bcc
 
         # Create an smtp object and send email
-        s = smtplib.SMTP('localhost')
+        s = smtplib.SMTP(server)
 
         email_msg.set_content(listserv_cmd)
         if not args.dry_run:


### PR DESCRIPTION
This PR is created to use the parameter values from the newly merged single config file `rabbit_config.py`. This file is created as a result of our decision to merge `mail_config.py` with the already existing `rabbit_config.py` to use a single config file for all rabbitmq agents. 
The deploy code from [PR#205](https://github.com/jprorama/CRI_XCBC/pull/205) will make sure all the parameters from the mail_config are templated via vars from ansible file `group_vars/all` and also moved into already existing `rabbit_config.py` jinja template.