### PR TITLE
Feat separate mail config

### DIFF
--- a/mail_config.py
+++ b/mail_config.py
@@ -1,14 +1,8 @@
-# Some variable for email
-Server = 'localhost'
-Admin_email = 'root@localhost'
-Sender = 'ROOT@LOCALHOST'
-Sender_alias = 'Services'
-Subject = 'New User Account'
-Info_url = 'https://www.google.com'
+import rabbit_config as rcfg
 
-Head = f"""From: {Sender_alias} <{Sender}>
+Head = f"""From: {rcfg.Sender_alias} <{rcfg.Sender}>
 To: <{{{{ to }}}}>
-Subject: {Subject}
+Subject: {rcfg.Subject}
 """
 
 Body = f"""
@@ -20,16 +14,16 @@ User ID:  {{{{ username }}}}
 ============================
 
 If you have any questions, please visit:
-{Info_url}
+{rcfg.Info_url}
 
-or email at {Admin_email}
+or email at {rcfg.Admin_email}
 
 Cheers,
 """
 
 Whole_mail = Head + Body
 
-UserReportHead = f"""From: {Sender_alias} <{Sender}>
-To: <{Admin_email}>
+UserReportHead = f"""From: {rcfg.Sender_alias} <{rcfg.Sender}>
+To: <{rcfg.Admin_email}>
 Subject: RC Account Creation Report: {{{{ fullname }}}}, {{{{ username }}}} """
 

--- a/notify_user.py
+++ b/notify_user.py
@@ -7,8 +7,8 @@ import dataset
 from rc_rmq import RCRMQ
 from jinja2 import Template
 from datetime import datetime
-import rabbit_config as mail_cfg
-
+import rabbit_config as rcfg
+import mail_config as mail_cfg
 task = 'notify_user'
 
 args = rc_util.get_args()
@@ -51,18 +51,18 @@ def notify_user(ch, method, properties, body):
 
         else:
             # Send email to user
-            receivers = [user_email, mail_cfg.Admin_email]
+            receivers = [user_email, rcfg.Admin_email]
             message = Template(mail_cfg.Whole_mail).render(username=username, to=user_email)
 
             if args.dry_run:
-                logger.info(f'smtp = smtplib.SMTP({mail_cfg.Server})')
-                logger.info(f'smtp.sendmail({mail_cfg.Sender}, {receivers}, message)')
+                logger.info(f'smtp = smtplib.SMTP({rcfg.Server})')
+                logger.info(f'smtp.sendmail({rcfg.Sender}, {receivers}, message)')
                 logger.info(f"table.update({{'username': {username}, 'count': 1, 'sent_at': datetime.now()}}, ['username'])")
 
             else:
                 errmsg = 'Sending email to user'
-                smtp = smtplib.SMTP(mail_cfg.Server)
-                smtp.sendmail(mail_cfg.Sender, receivers, message)
+                smtp = smtplib.SMTP(rcfg.Server)
+                smtp.sendmail(rcfg.Sender, receivers, message)
 
                 logger.debug(f'Email sent to: {user_email}')
 


### PR DESCRIPTION
This PR puts the mail template containing the headers and body for admin report and user notification in mail-config and moves the email related vars like sender server etc. to rabbit_config
Changes to notify_user accordingly per above changes.