### PR TITLE
Rename variable for mail server

### DIFF
--- a/prod_rmq_agents/notify_user.py
+++ b/prod_rmq_agents/notify_user.py
@@ -55,13 +55,13 @@ def notify_user(ch, method, properties, body):
             message = Template(mail_cfg.Whole_mail).render(username=username, to=user_email)
 
             if args.dry_run:
-                logger.info(f'smtp = smtplib.SMTP({rcfg.Server})')
+                logger.info(f'smtp = smtplib.SMTP({rcfg.Mail_server})')
                 logger.info(f'smtp.sendmail({rcfg.Sender}, {receivers}, message)')
                 logger.info(f"table.update({{'username': {username}, 'count': 1, 'sent_at': datetime.now()}}, ['username'])")
 
             else:
                 errmsg = 'Sending email to user'
-                smtp = smtplib.SMTP(rcfg.Server)
+                smtp = smtplib.SMTP(rcfg.Mail_server)
                 smtp.sendmail(rcfg.Sender, receivers, message)
 
                 logger.debug(f'Email sent to: {user_email}')

--- a/prod_rmq_agents/subscribe_mail_lists.py
+++ b/prod_rmq_agents/subscribe_mail_lists.py
@@ -32,7 +32,7 @@ def mail_list_subscription(ch, method, properties, body):
     mail_list_admin = rcfg.Sender
     mail_list = rcfg.Mail_list
     mail_list_bcc = rcfg.Mail_list_bcc
-    server = rcfg.Server
+    server = rcfg.Mail_server
 
     listserv_cmd = f'QUIET ADD hpc-announce {email} {fullname} \
                    \nQUIET ADD hpc-users {email} {fullname}'

--- a/prod_rmq_agents/task_manager.py
+++ b/prod_rmq_agents/task_manager.py
@@ -74,12 +74,12 @@ def notify_admin(username, user_record):
             message += msg + "\n"
 
     if args.dry_run:
-        logger.info(f'smtp = smtplib.SMTP({rcfg.Server})')
+        logger.info(f'smtp = smtplib.SMTP({rcfg.Mail_server})')
         logger.info(f'smtp.sendmail({rcfg.Sender}, {rcfg.Admin_email}, message)')
         logger.info(message)
 
     else:
-        smtp = smtplib.SMTP(rcfg.Server)
+        smtp = smtplib.SMTP(rcfg.Mail_server)
         smtp.sendmail(rcfg.Sender, receivers, message)
 
         logger.debug(f'User report sent to: {rcfg.Admin_email}')

--- a/rabbit_config.py.example
+++ b/rabbit_config.py.example
@@ -16,7 +16,7 @@ User_dirs = ['/home', '/data/user', '/data/scratch']
 rc_users_ldap_repo_loc = "~/git/rc-users"
 
 # Config related to email
-Server = 'localhost'
+Mail_server = 'localhost'
 Admin_email = 'root@localhost'
 Sender = 'ROOT@LOCALHOST'
 Sender_alias = 'Services'


### PR DESCRIPTION
When we merge mail_config and rabbit_config,
 there's two Server in both files for different purposes.

Rename the one for mail server to Mail_server.