### PR TITLE
Add Support email variable

### DIFF
--- a/rabbit_config.py.example
+++ b/rabbit_config.py.example
@@ -24,6 +24,7 @@ Subject = 'New User Account'
 Info_url = 'https://www.google.com'
 Mail_list = 'root@localhost'
 Mail_list_bcc = 'cmsupport@localhost'
+Support_email = 'support@listserv.uab.edu'
 
 Head = f"""From: {Sender_alias} <{Sender}>
 To: <{{{{ to }}}}>


### PR DESCRIPTION
Task manager failed to start due to `Support_email` variable is missing.