### PR TITLE
Fix user reg logger

### DIFF
--- a/prod_rmq_agents/user_reg_logger.py
+++ b/prod_rmq_agents/user_reg_logger.py
@@ -19,7 +19,7 @@ args = rc_util.get_args()
 logger = rc_util.get_logger()
 
 # Open registry table in DB
-db = dataset.connect("sqlite:///reg_logger.db")
+db = dataset.connect("sqlite:///.agent_db/reg_logger.db")
 account_req_table = db["registry"]
 
 # Define registration logger callback

--- a/prod_rmq_agents/user_reg_logger.py
+++ b/prod_rmq_agents/user_reg_logger.py
@@ -37,5 +37,5 @@ logger.info("Start listening to queue: {}".format(task))
 
 # Start consuming messages from queue with callback function
 rc_rmq.start_consume(
-    {"queue": task, "routing_key": "create.*", "cb": log_registration}
+    {"queue": task, "routing_key": "request.*", "cb": log_registration}
 )

--- a/prod_rmq_agents/user_reg_logger.py
+++ b/prod_rmq_agents/user_reg_logger.py
@@ -26,7 +26,7 @@ account_req_table = db["registry"]
 def log_registration(ch, method, properties, body):
 
     account_req = json.loads(body)
-    account_req["req_time"] = (datetime.now(),)
+    account_req["req_time"] = datetime.now()
     account_req_table.insert(account_req)
     logger.info("logged account request for %s", account_req["username"])
 


### PR DESCRIPTION
Since we merge create account agent into `get_next_uid_gid` agent, the `create` level, which `user_reg_logger` subscribes to, has been removed.
This PR changes the routing key accordingly.