### PR TITLE
Remove pyldap from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pika==1.1.0
-pyldap==3.0.0.post1
 dataset==1.3.1
 Jinja2==2.11.2
 sh==1.12.14


### PR DESCRIPTION
We are not using it, and it causes the ansible playbook to fail.