### PR TITLE
Update rcrmq class

### DIFF
--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -124,11 +124,13 @@ class RCRMQ(object):
         routing_key = obj.get("routing_key", queue or None)
         durable = obj.get("durable", True)
         exclusive = obj.get("exclusive", False)
+        bind = obj.get("bind", True)
 
         if self._connection is None:
             self.connect()
 
-        self.bind_queue(queue, routing_key, durable, exclusive)
+        if bind:
+            self.bind_queue(queue, routing_key, durable, exclusive)
 
         if self.DEBUG:
             print("Queue: " + queue + "\nRouting_key: " + routing_key)

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -84,6 +84,9 @@ class RCRMQ(object):
         self, queue="", routing_key=None, durable=True, exclusive=False
     ):
 
+        if self._connection is None:
+            self.connect()
+
         self._channel.queue_declare(
             queue=queue, durable=durable, exclusive=exclusive
         )

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -87,15 +87,17 @@ class RCRMQ(object):
         if self._connection is None:
             self.connect()
 
-        self._channel.queue_declare(
+        result = self._channel.queue_declare(
             queue=queue, durable=durable, exclusive=exclusive
         )
 
         self._channel.queue_bind(
             exchange=self.EXCHANGE,
-            queue=queue,
+            queue=result.method.queue,
             routing_key=routing_key,
         )
+
+        return result.method.queue
 
     def disconnect(self):
         self._channel.close()

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -109,6 +109,7 @@ class RCRMQ(object):
 
     def publish_msg(self, obj):
         routing_key = obj.get("routing_key")
+        props = obj.get("props")
 
         if self._connection is None:
             self.connect()
@@ -116,6 +117,7 @@ class RCRMQ(object):
         self._channel.basic_publish(
             exchange=self.EXCHANGE,
             routing_key=routing_key,
+            properties=props,
             body=json.dumps(obj["msg"]),
         )
 

--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -80,8 +80,14 @@ class RCRMQ(object):
             durable=True,
         )
 
-    def bind_queue(self, queue="", routing_key=None, durable=True):
-        self._channel.queue_declare(queue=queue, durable=durable)
+    def bind_queue(
+        self, queue="", routing_key=None, durable=True, exclusive=False
+    ):
+
+        self._channel.queue_declare(
+            queue=queue, durable=durable, exclusive=exclusive
+        )
+
         self._channel.queue_bind(
             exchange=self.EXCHANGE,
             queue=queue,
@@ -112,11 +118,12 @@ class RCRMQ(object):
         queue = obj.get("queue", "")
         routing_key = obj.get("routing_key", queue or None)
         durable = obj.get("durable", True)
+        exclusive = obj.get("exclusive", False)
 
         if self._connection is None:
             self.connect()
 
-        self.bind_queue(queue, routing_key, durable)
+        self.bind_queue(queue, routing_key, durable, exclusive)
 
         if self.DEBUG:
             print("Queue: " + queue + "\nRouting_key: " + routing_key)


### PR DESCRIPTION
The previous design was based on these assumptions:
  RCRMQ instance only need to do either publish or consume
  RCRMQ instance only need to interact with one single queue

However, in order to perform an RPC-like call, an instance will need to do both
publish and consume. In addition, publish and consume are not necessary
to the same queue. So, saving queue name as a single variable inside the
instance is not viable anymore.