### PR TITLE
Check connection before disconnect in rc_rmq

### DIFF
--- a/rc_rmq.py
+++ b/rc_rmq.py
@@ -100,9 +100,10 @@ class RCRMQ(object):
         return result.method.queue
 
     def disconnect(self):
-        self._channel.close()
-        self._connection.close()
-        self._connection = None
+        if self._connection:
+            self._channel.close()
+            self._connection.close()
+            self._connection = None
 
     def delete_queue(self, queue):
         self._channel.queue_delete(queue)


### PR DESCRIPTION
Naively calling disconnect() from RCRMQ will throw the following exception:
`pika.exceptions.ChannelWrongStateError: Channel is closed.`

To avoid this from happening, check the connection in the disconnect function.