### PR TITLE
Add greenlet in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dataset==1.3.1
 Jinja2==2.11.2
 sh==1.12.14
 pre-commit==2.12.1
+greenlet==1.1.3


### PR DESCRIPTION
The CoD deployment fail at `pip install -r requirements.txt`. 
After investigation, it seems to be `greenlet` one of the dependencies by `dataset` not pin to a specific version and this newer version causes the installation to fail. 