### PR TITLE
Update black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/psf/black
-    rev: 21.5b0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
Got an error while trying to commit:

```
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/Users/louistw/.cache/pre-commit/repou8gfch58/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/Users/louistw/.cache/pre-commit/repou8gfch58/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 7019, in patched_main
    patch_click()
  File "/Users/louistw/.cache/pre-commit/repou8gfch58/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 7008, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/Users/louistw/.cache/pre-commit/repou8gfch58/py_env-python3/lib/python3.9/site-packages/click/__init__.py)
```

This seems to be an issue from one of the dependencies from black. Bumping black to the latest version solved the issue.